### PR TITLE
Feature/fix ios audio

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderlandcloud/client",
-  "version": "0.1.3-beta-1",
+  "version": "0.1.3-beta-2",
   "description": "Wonderland Engine multi-user server client and components.",
   "main": "dist/index.js",
   "wonderlandengine": {},

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderlandcloud/client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Wonderland Engine multi-user server client and components.",
   "main": "dist/index.js",
   "wonderlandengine": {},

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderlandcloud/client",
-  "version": "0.1.2",
+  "version": "0.1.3-beta-1",
   "description": "Wonderland Engine multi-user server client and components.",
   "main": "dist/index.js",
   "wonderlandengine": {},

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderlandcloud/client",
-  "version": "0.1.3-beta-2",
+  "version": "0.1.3",
   "description": "Wonderland Engine multi-user server client and components.",
   "main": "dist/index.js",
   "wonderlandengine": {},

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wonderlandcloud/client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Wonderland Engine multi-user server client and components.",
   "main": "dist/index.js",
   "wonderlandengine": {},

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -78,7 +78,6 @@ export class WonderlandClient {
   inputDeviceId?: string;
   outputDeviceId?: string;
   audio: boolean;
-  remoteMedia?: HTMLElement | null;
   receivedData: any[];
   incomingRemoteStreams?: number;
   context?: AudioContext;
@@ -119,8 +118,6 @@ export class WonderlandClient {
     this._debugLog('client created with options:', mergedOptions);
     // TODO DO NOT MIX AUDIO IF NOT ENABLED ON CLIENT
     if (this.audio) {
-      this.remoteMedia = document.getElementById('remoteMedia');
-      this.waitForAudioContext();
     }
     this.receivedData = [];
     this.peerConnection = new RTCPeerConnection({
@@ -343,7 +340,7 @@ export class WonderlandClient {
     if (this.audioAdded) return;
     if (!this.audioAddingPromise) {
       this.audioAddingPromise = new Promise(async (resolve) => {
-        await this.waitForAudioContext();
+
         const media = await navigator.mediaDevices.getUserMedia({
           audio: {
             deviceId: this.inputDeviceId || void 0,


### PR DESCRIPTION
# client

* iOS:  use audioSession to explicitly use `playback` type when playing remote audio, to ensure we use the right speakers/ airpods