### PR TITLE
client: Properly handle activate/deactivate of networked-component

### DIFF
--- a/client/src/components/network-manager.ts
+++ b/client/src/components/network-manager.ts
@@ -34,8 +34,13 @@ export class NetworkManager {
     }
   }
 
-  get selfPlayerId(): string | undefined{
-    return this.client ? this.client.id : undefined;
+  unregisterNetworkedComponent(c: NetworkedComponent, write: boolean) {
+    console.log('unregistered', write ? 'write' : 'read', 'comp', c.networkId);
+    if (write) {
+      this.writeComponents.delete(c.networkId);
+    } else {
+      this.readComponents.delete(c.networkId);
+    }
   }
 
 

--- a/client/src/components/networked-component.ts
+++ b/client/src/components/networked-component.ts
@@ -30,6 +30,13 @@ export class NetworkedComponent extends Component {
 
   start() {
     if (this.networkId < 0) throw new Error('networkId is not configured');
+  }
+
+  onActivate() {
     networkManager.registerNetworkedComponent(this, this.mode == 'send');
+  }
+
+  onDeactivate() {
+    networkManager.unregisterNetworkedComponent(this, this.mode == 'send');
   }
 }


### PR DESCRIPTION
Since destroying components did not unregister the component for updates, it would access destroyed components/objects in the next update.